### PR TITLE
Got delete term working

### DIFF
--- a/events/domEvents.js
+++ b/events/domEvents.js
@@ -1,7 +1,7 @@
 import addTermForm from '../forms/addTerm';
-import { getSingleTerm, deleteTerm } from '../api/termData';
-import viewTerm from '../pages/viewTerm';
-import { showTerms } from '../pages/showTerms';
+import { getSingleTerm, deleteTerm, getTerms } from '../api/termData';
+import { viewTerm } from '../pages/viewTerm';
+import { emptyTerms, showTerms } from '../pages/showTerms';
 
 const domEvents = (user) => {
   document.querySelector('#navigation').addEventListener('click', (e) => {
@@ -22,8 +22,19 @@ const domEvents = (user) => {
     }
 
     if (e.target.id.includes('delete-term-btn')) {
-      const [, firebaseKey] = e.target.id.split('--');
-      deleteTerm(firebaseKey).then(showTerms);
+      // eslint-disable-next-line no-alert
+      if (window.confirm('Are you sure you want to delete?')) {
+        const [, firebaseKey] = e.target.id.split('--');
+        deleteTerm(firebaseKey).then(() => {
+          getTerms(user.uid).then((array) => {
+            if (array.length) {
+              showTerms(array);
+            } else {
+              emptyTerms();
+            }
+          });
+        });
+      }
     }
   });
 };

--- a/pages/viewTerm.js
+++ b/pages/viewTerm.js
@@ -1,6 +1,11 @@
 import clearDom from '../utils/clearDom';
 import renderToDom from '../utils/renderToDom';
 
+const emptyTerms = () => {
+  const domString = '<h1>No Terms</h1>';
+  renderToDom('#view', domString);
+};
+
 const viewTerm = (obj) => {
   clearDom();
 
@@ -22,4 +27,4 @@ const viewTerm = (obj) => {
   renderToDom('#view', domString);
 };
 
-export default viewTerm;
+export { viewTerm, emptyTerms };


### PR DESCRIPTION
## Description
Fixed the API call that was preventing my delete term from working, ended up using an if else statement at the end that made the page re-render the remaining terms instead of breaking.

## Motivation and Context
Change was needed because previously hitting the delete button would cause a runtime error.

## How Can This Be Tested?
Can be tested by hitting delete in any of the cards on the main page or the individual term page, after hitting the main page will reload without the deleted term.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
